### PR TITLE
fixed corpus search bar alignment and CLAWS7 link

### DIFF
--- a/ComSemApp/templates/ComSemApp/corpus/corpus_search.html
+++ b/ComSemApp/templates/ComSemApp/corpus/corpus_search.html
@@ -21,7 +21,7 @@
 <input type="hidden" name="searchCriteria" id="searchCriteria" />
 <div class="row">
 	<!-- left most column -->
-	<div class="col-lg-4">
+	<div class="col-lg-4" style="margin-top: -24px;">
 
 		<!-- Space for user to enter the first word, mandatory -->
 		<div class="form-group">
@@ -36,7 +36,7 @@
 				</h4>
 			</div>
 			<div class="col-sm-12 col-md-6">
-				<a href= "javascript:window.open('http://ucrel.lancs.ac.uk/claws7tags.html','width=700,height=650')" target="_blank" class="text-muted m-b-10 font-13 float-right">About CLAWS7 Tagset</a>
+				<a href= "http://ucrel.lancs.ac.uk/claws7tags.html" target="_blank" class="text-muted m-b-10 font-13 float-right" style="text-decoration: underline;">About CLAWS7 Tagset</a>
 			</div>
 		</div>
 


### PR DESCRIPTION
In corpus_search.html, the search bar columns were not lined up so I lowered the leftmost column's top margin by 24px. The javascript for opening the CLAWS7 link was also not working, so I linked the site directly. I also decided to underline the link. It makes the link appear more clickable.

| Before      | After      |
|-------------|------------|
| ![Screenshot 2021-11-15 at 18 06 45](https://user-images.githubusercontent.com/17057932/141832298-b27de177-8975-477d-a518-62f075e83ef3.png) | ![Screenshot 2021-11-15 at 18 06 30](https://user-images.githubusercontent.com/17057932/141832314-9cb64ed0-6727-41bd-90fb-5fea7c38a803.png) |