### PR TITLE
153 create unit tests for speakingpracticeattempt model

### DIFF
--- a/ComSemApp/models.py
+++ b/ComSemApp/models.py
@@ -329,7 +329,7 @@ class SpeakingPracticeAttempt(models.Model):
     # The student's correctness score --- Accepts numbers 00.00-100.00
     correct = models.DecimalField(max_digits=5, decimal_places=2, validators=[MinValueValidator(0), MaxValueValidator(100)], verbose_name='Correctness Score')
     # The number of words per minute in the student's recording --- Accepts numbers 000.00-999.99
-    wpm = models.DecimalField(max_digits=5,decimal_places=2, verbose_name='Words per Minute')
+    wpm = models.DecimalField(max_digits=5,decimal_places=2, validators=[MinValueValidator(0)], verbose_name='Words per Minute')
 
     def __str__(self):
         return f"{self.id}: {self.expression} - {self.correct}% ({self.date.strftime('%d %b %Y')})"

--- a/ComSemApp/tests/test_models.py
+++ b/ComSemApp/tests/test_models.py
@@ -1,0 +1,32 @@
+from django.db.utils import IntegrityError
+from django.db import transaction
+
+from ComSemApp.models import *
+from ComSemApp.libs.factories import BaseTestCase
+
+class TestSpeakingPracticeAttempt(BaseTestCase):
+    """
+        Creates a test 
+    """
+    def setUp(self):
+        self.expression = self.db_create_expression()
+    
+    def test_exception_on_null_fields(self):
+        with transaction.atomic():
+            self.assertRaises(IntegrityError, SpeakingPracticeAttempt.objects.create)
+        with transaction.atomic():
+            self.assertRaises(IntegrityError, SpeakingPracticeAttempt.objects.create, expression=self.expression)
+        with transaction.atomic():
+            self.assertRaises(IntegrityError, SpeakingPracticeAttempt.objects.create, expression=self.expression, correct=90)
+        with transaction.atomic():
+            self.assertRaises(IntegrityError, SpeakingPracticeAttempt.objects.create, expression=self.expression, wpm=100)
+        with transaction.atomic():
+            self.assertRaises(IntegrityError, SpeakingPracticeAttempt.objects.create, correct=90)
+        with transaction.atomic():
+            self.assertRaises(IntegrityError, SpeakingPracticeAttempt.objects.create, correct=90, wpm=100)
+        with transaction.atomic():
+            self.assertRaises(IntegrityError, SpeakingPracticeAttempt.objects.create, wpm=100)
+
+    def test_no_error_with_allowed_fields_null(self):
+        with transaction.atomic():
+            self.assertIsNotNone(SpeakingPracticeAttempt.objects.create(expression=self.expression, correct=90, wpm=100))

--- a/ComSemApp/tests/test_models.py
+++ b/ComSemApp/tests/test_models.py
@@ -60,3 +60,20 @@ class TestSpeakingPracticeAttempt(BaseTestCase):
         # correct too low (negative)
         with transaction.atomic():
             self.assertRaises(ValidationError, SpeakingPracticeAttempt.objects.create(expression=self.expression, correct=-1, wpm=100).full_clean)
+
+    def test_multiple_attempts_on_same_expression_are_unique(self) -> None:
+        """
+            Tests that attempts for the same expression are created as separate objects
+        """
+        attempt1 : SpeakingPracticeAttempt = SpeakingPracticeAttempt.objects.create(expression=self.expression, correct=90, wpm=100)
+        attempt2 : SpeakingPracticeAttempt = SpeakingPracticeAttempt.objects.create(expression=self.expression, correct=50, wpm=123)
+        self.assertNotEqual(attempt1, attempt2)
+
+    def test_values_read_from_object_equal_those_assigned(self) -> None:
+        """
+            Tests that the object created has values identical to those assigned
+        """
+        attempt : SpeakingPracticeAttempt = SpeakingPracticeAttempt.objects.create(expression=self.expression, correct=90, wpm=100)
+        self.assertEqual(self.expression, attempt.expression)
+        self.assertEqual(90, attempt.correct)
+        self.assertEqual(100, attempt.wpm)

--- a/ComSemApp/tests/test_models.py
+++ b/ComSemApp/tests/test_models.py
@@ -9,12 +9,20 @@ from ComSemApp.libs.factories import BaseTestCase
 
 class TestSpeakingPracticeAttempt(BaseTestCase):
     """
-        Creates a test 
+        Test class for the SpeakingPracticeAttempt database model
+        Inherits from a custom BaseTestCase class with extra methods for easy database manipulation
     """
-    def setUp(self):
+    def setUp(self) -> None:
+        """
+            Implementation of standard setUp function.
+            Creates one instance of Expression for the SpeakingPracticeAttempts to reference
+        """
         self.expression = self.db_create_expression()
     
-    def test_exception_on_null_fields(self):
+    def test_exception_on_null_fields(self) -> None:
+        """
+            Tests that an exception is thrown when any Not Null field is undefined
+        """
         with transaction.atomic():
             self.assertRaises(IntegrityError, SpeakingPracticeAttempt.objects.create)
         with transaction.atomic():
@@ -30,10 +38,16 @@ class TestSpeakingPracticeAttempt(BaseTestCase):
         with transaction.atomic():
             self.assertRaises(IntegrityError, SpeakingPracticeAttempt.objects.create, wpm=100)
 
-    def test_no_error_with_allowed_fields_null(self):
+    def test_no_error_with_allowed_fields_null(self) -> None:
+        """
+            Tests that an exception is not thrown when fields which are allowed to be null are undefined
+        """
         self.assertIsNotNone(SpeakingPracticeAttempt.objects.create(expression=self.expression, correct=90, wpm=100))
 
-    def test_exception_on_out_of_range_values(self):
+    def test_exception_on_out_of_range_values(self) -> None:
+        """
+            Tests that exceptions are thrown when validating values that are out of range
+        """
         # wpm too high
         with transaction.atomic():
             self.assertRaises(InvalidOperation, SpeakingPracticeAttempt.objects.create, expression=self.expression, correct=90, wpm=1000)


### PR DESCRIPTION
Added a few tests for the SpeakingPracticeAttempt database model. Some of these are probably unnecessary.
Also includes a fix on the model.

To run just these tests with a useful level of verbosity, use the command "python manage.py test ComSemApp.tests -v2".
